### PR TITLE
feat: Implement dueString/dueLang in task tools

### DIFF
--- a/src/tools/add-task.ts
+++ b/src/tools/add-task.ts
@@ -22,14 +22,14 @@ export function registerAddTask(server: McpServer, api: TodoistApi) {
                 .describe('Task priority from 1 (normal) to 4 (urgent)'),
             labels: z.array(z.string()).optional(),
             parentId: z.string().optional().describe('The ID of a parent task'),
-            deadlineDate: z
+            dueString: z
                 .string()
                 .optional()
-                .describe('Specific date in YYYY-MM-DD format relative to user’s timezone.'),
-            deadlineLang: z
+                .describe('Human-friendly string representation of the due date (e.g. "tomorrow at 10am").'),
+            dueLang: z
                 .string()
                 .optional()
-                .describe('2-letter code specifying language of deadline.'),
+                .describe('2-letter code specifying language of dueString.'),
         },
         async ({
             content,
@@ -38,8 +38,8 @@ export function registerAddTask(server: McpServer, api: TodoistApi) {
             assigneeId,
             priority,
             labels,
-            deadlineDate,
-            deadlineLang,
+            dueString,
+            dueLang,
         }) => {
             const task = await api.addTask({
                 content,
@@ -48,8 +48,8 @@ export function registerAddTask(server: McpServer, api: TodoistApi) {
                 assigneeId,
                 priority,
                 labels,
-                deadlineDate,
-                deadlineLang,
+                dueString,
+                dueLang,
             })
             return {
                 content: [

--- a/src/tools/update-task.ts
+++ b/src/tools/update-task.ts
@@ -21,14 +21,14 @@ export function registerUpdateTask(server: McpServer, api: TodoistApi) {
                 .optional()
                 .describe('Task priority from 1 (normal) to 4 (urgent)'),
             labels: z.array(z.string()).optional(),
-            deadlineDate: z
+            dueString: z
                 .string()
                 .optional()
-                .describe('Specific date in YYYY-MM-DD format relative to user’s timezone.'),
-            deadlineLang: z
+                .describe('Human-friendly string representation of the due date (e.g. "tomorrow at 10am").'),
+            dueLang: z
                 .string()
                 .optional()
-                .describe('2-letter code specifying language of deadline.'),
+                .describe('2-letter code specifying language of dueString.'),
         },
         async ({
             taskId,
@@ -37,8 +37,8 @@ export function registerUpdateTask(server: McpServer, api: TodoistApi) {
             assigneeId,
             priority,
             labels,
-            deadlineDate,
-            deadlineLang,
+            dueString,
+            dueLang,
         }) => {
             const task = await api.updateTask(taskId, {
                 content,
@@ -46,8 +46,8 @@ export function registerUpdateTask(server: McpServer, api: TodoistApi) {
                 assigneeId,
                 priority,
                 labels,
-                deadlineDate,
-                deadlineLang,
+                dueString,
+                dueLang,
             })
             return {
                 content: [{ type: 'text', text: JSON.stringify(task, null, 2) }],


### PR DESCRIPTION
Replaced deadlineDate and deadlineLang parameters with dueString and dueLang in the add-task and update-task tools to align with Todoist API's natural language date handling for due dates.